### PR TITLE
Fix: Add default boolean values to config getters

### DIFF
--- a/lib/ash_typescript/rpc.ex
+++ b/lib/ash_typescript/rpc.ex
@@ -233,7 +233,7 @@ defmodule AshTypescript.Rpc do
   Defaults to false (opt-in feature).
   """
   def generate_zod_schemas? do
-    Application.get_env(:ash_typescript, :generate_zod_schemas)
+    Application.get_env(:ash_typescript, :generate_zod_schemas, false)
   end
 
   @doc """
@@ -274,7 +274,7 @@ defmodule AshTypescript.Rpc do
   Defaults to false.
   """
   def generate_validation_functions? do
-    Application.get_env(:ash_typescript, :generate_validation_functions)
+    Application.get_env(:ash_typescript, :generate_validation_functions, false)
   end
 
   @doc """


### PR DESCRIPTION
- Add default value 'true' to generate_zod_schemas?
- Add default value 'true' to generate_validation_functions?
- Fixes BadBooleanError when config not explicitly set


# Contributor checklist

Leave anything that you believe does not apply unchecked.
- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies

Fixes #19 