### PR TITLE
Update input_types.ex allow_nil

### DIFF
--- a/lib/ash_typescript/rpc/codegen/type_generators/input_types.ex
+++ b/lib/ash_typescript/rpc/codegen/type_generators/input_types.ex
@@ -118,7 +118,7 @@ defmodule AshTypescript.Rpc.Codegen.TypeGenerators.InputTypes do
               accept_field_defs =
                 Enum.map(action.accept, fn field_name ->
                   attr = Ash.Resource.Info.attribute(resource, field_name)
-                  optional = attr.allow_nil? || attr.default != nil
+                  optional = field_name in action.allow_nil_input || attr.allow_nil? || attr.default != nil
                   base_type = AshTypescript.Codegen.get_ts_input_type(attr)
                   field_type = if attr.allow_nil?, do: "#{base_type} | null", else: base_type
 


### PR DESCRIPTION
When using accept in Ash update actions, AshTypescript incorrectly generates TypeScript types that require all accepted fields, even though update actions should only require the fields being updated. Example: An `:update_me` action that accepts 8 fields generates a TypeScript type requiring ALL 8 fields to be provided, when in reality you might only want to update 1 field (like timezone).
```
update :update_me do
  accept [:email, :first_name, :last_name, :localization, ...]
end
```
Generates:

```
type UpdateMeInput = {
  email: string;          // ❌ Required
  firstName: string;      // ❌ Required  
  lastName: string;       // ❌ Required
  localization: {...};    // ❌ Required
  // etc...
}
```

Why This Happens
AshTypescript determines field optionality based solely on the attribute's `allow_nil?` setting: If `allow_nil? false` on the attribute then the field is required in TypeScript If `allow_nil? true` on the attribute then the field is optional in TypeScript This logic makes sense for `create` actions (where required attributes must be provided), but not for `update` actions (where you only update what you want to change). The Solution: `allow_nil_input`
Ash provides `allow_nil_input` specifically for this use case - it marks fields that would normally be required as optional for a specific action:
```
update :update_me do
  accept [:email, :first_name, :last_name, :localization, ...]
  
  allow_nil_input [:email, :first_name, :last_name, :localization, ...]
end
```
The Fix
AshTypescript needs to check `allow_nil_input` when determining field optionality. The fix is a one-line change in the type generation logic:
```
# Current (incorrect)
optional = attr.allow_nil? || attr.default != nil

# Fixed
optional = field_name in action.allow_nil_input || attr.allow_nil? || attr.default != nil
```

This makes any field listed in `allow_nil_input` optional in the generated TypeScript type, allowing proper partial updates while maintaining type safety.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [❌ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [❌  ] Refactoring
- [ ] Update dependencies
