### PR TITLE
fix(field-names): support bidirectional field name mapping for field selection

### DIFF
--- a/lib/ash_typescript/rpc/field_processing/validator.ex
+++ b/lib/ash_typescript/rpc/field_processing/validator.ex
@@ -73,12 +73,9 @@ defmodule AshTypescript.Rpc.FieldProcessing.Validator do
             [field_name]
 
           field_name when is_binary(field_name) ->
-            try do
-              [String.to_existing_atom(field_name)]
-            rescue
-              _ ->
-                throw({:invalid_field_type, field_name, path})
-            end
+            # String field names are valid - they will be converted to atoms later
+            # We just need to use a consistent key for duplicate detection
+            [field_name]
 
           %{} = field_map ->
             Map.keys(field_map)

--- a/test/support/resources/user.ex
+++ b/test/support/resources/user.ex
@@ -14,7 +14,11 @@ defmodule AshTypescript.Test.User do
 
   typescript do
     type_name "User"
-    field_names address_line_1: :address_line1, is_active?: :is_active
+
+    field_names address_line_1: :address_line1,
+                is_active?: :is_active,
+                available_for_purchase?: :availableForPurchase
+
     argument_names read_with_invalid_arg: [is_active?: :is_active]
   end
 
@@ -101,6 +105,10 @@ defmodule AshTypescript.Test.User do
     end
 
     calculate :is_active?, :boolean, expr(true) do
+      public? true
+    end
+
+    calculate :available_for_purchase?, :boolean, expr(true) do
       public? true
     end
   end


### PR DESCRIPTION
field_names mapping only worked for output (Elixir to TypeScript) but failed
for input field selection (TypeScript to Elixir) with "Unknown field" error.

When a client sends "availableForPurchase" in fields array, the formatter
converts it to snake_case ("available_for_purchase"). get_original_field_name
tried to match this against mapping values, but the value was :availableForPurchase
(camelCase), so no match was found.

Changes:
- get_original_field_name now also compares snake_case version of mapped values
- check_for_duplicate_fields accepts string field names without throwing
- process_resource_fields checks get_original_field_name before String.to_existing_atom
