### PR TITLE
refactor: extract shared introspection utilities to ash_introspection package

### DIFF
--- a/lib/ash_typescript/field_formatter.ex
+++ b/lib/ash_typescript/field_formatter.ex
@@ -6,12 +6,17 @@ defmodule AshTypescript.FieldFormatter do
   @moduledoc """
   Handles field name formatting for input parameters, output fields, and TypeScript generation.
 
-  Supports built-in formatters and custom formatter functions.
+  Delegates to `AshIntrospection.FieldFormatter` for the core functionality.
   """
 
-  import AshTypescript.Helpers
-
   alias AshTypescript.TypeSystem.Introspection
+
+  # Delegate core functions to AshIntrospection.FieldFormatter
+  defdelegate parse_input_field(field_name, formatter), to: AshIntrospection.FieldFormatter
+  defdelegate format_fields(fields, formatter), to: AshIntrospection.FieldFormatter
+  defdelegate parse_input_fields(fields, formatter), to: AshIntrospection.FieldFormatter
+  defdelegate parse_input_value(value, formatter), to: AshIntrospection.FieldFormatter
+  defdelegate format_field_name(field_name, formatter), to: AshIntrospection.FieldFormatter
 
   @doc """
   Formats a field name for client output, optionally applying resource/type-level
@@ -79,38 +84,6 @@ defmodule AshTypescript.FieldFormatter do
   end
 
   @doc """
-  Parses input field names from client format to internal format.
-
-  This is used for converting incoming client field names to the internal
-  Elixir atom keys that Ash expects.
-
-  ## Examples
-
-      iex> AshTypescript.FieldFormatter.parse_input_field("userName", :camel_case)
-      :user_name
-  """
-  def parse_input_field(field_name, formatter)
-      when is_binary(field_name) or is_atom(field_name) do
-    internal_name = parse_field_name(field_name, formatter)
-
-    case internal_name do
-      name when is_binary(name) ->
-        try do
-          String.to_existing_atom(name)
-        rescue
-          ArgumentError ->
-            name
-        end
-
-      name when is_atom(name) ->
-        name
-
-      name ->
-        name
-    end
-  end
-
-  @doc """
   Converts a field name to an atom, applying the formatter for case conversion.
 
   Unlike `parse_input_field/2` which tries to use existing atoms, this function
@@ -133,152 +106,6 @@ defmodule AshTypescript.FieldFormatter do
     case result do
       atom when is_atom(atom) -> atom
       string when is_binary(string) -> String.to_atom(string)
-    end
-  end
-
-  @doc """
-  Formats a map of fields, converting all keys using the specified formatter.
-
-  ## Examples
-
-      iex> AshTypescript.FieldFormatter.format_fields(%{user_name: "John", user_email: "john@example.com"}, :camel_case)
-      %{"userName" => "John", "userEmail" => "john@example.com"}
-  """
-  def format_fields(fields, formatter) when is_map(fields) do
-    Enum.into(fields, %{}, fn {key, value} ->
-      formatted_key = format_field_name(key, formatter)
-      {formatted_key, value}
-    end)
-  end
-
-  @doc """
-  Parses a map of input fields, converting all keys from client format to internal format.
-
-  Recursively processes nested maps and arrays to ensure all field names are properly formatted.
-  This is essential for union types and embedded resources that contain nested field structures.
-
-  ## Examples
-
-      iex> AshTypescript.FieldFormatter.parse_input_fields(%{"userName" => "John", "userEmail" => "john@example.com"}, :camel_case)
-      %{user_name: "John", user_email: "john@example.com"}
-
-      iex> AshTypescript.FieldFormatter.parse_input_fields(%{"attachments" => [%{"mimeType" => "pdf", "attachmentType" => "file"}]}, :camel_case)
-      %{attachments: [%{mime_type: "pdf", attachment_type: "file"}]}
-  """
-  def parse_input_fields(fields, formatter) when is_map(fields) do
-    Enum.into(fields, %{}, fn {key, value} ->
-      internal_key = parse_input_field(key, formatter)
-      formatted_value = parse_input_value(value, formatter)
-      {internal_key, formatted_value}
-    end)
-  end
-
-  @doc """
-  Recursively parses input values, handling nested structures.
-
-  This function ensures that all nested maps and arrays containing maps
-  have their field names properly formatted according to the formatter.
-
-  Only handles JSON-decoded data (maps, lists, primitives) - no structs.
-  """
-  def parse_input_value(value, formatter) do
-    case value do
-      map when is_map(map) ->
-        parse_input_fields(map, formatter)
-
-      list when is_list(list) ->
-        Enum.map(list, fn item -> parse_input_value(item, formatter) end)
-
-      primitive ->
-        primitive
-    end
-  end
-
-  @doc """
-  Formats a field name using the configured formatter.
-
-  ## Examples
-
-      iex> AshTypescript.FieldFormatter.format_field_name(:user_name, :camel_case)
-      "userName"
-
-      iex> AshTypescript.FieldFormatter.format_field_name(:user_name, :snake_case)
-      "user_name"
-
-      iex> AshTypescript.FieldFormatter.format_field_name("user_name", :pascal_case)
-      "UserName"
-  """
-  def format_field_name(field_name, formatter) do
-    string_field = to_string(field_name)
-
-    case formatter do
-      :camel_case ->
-        if is_camel_case?(string_field) do
-          string_field
-        else
-          snake_to_camel_case(string_field)
-        end
-
-      :pascal_case ->
-        if is_pascal_case?(string_field) do
-          string_field
-        else
-          snake_to_pascal_case(string_field)
-        end
-
-      :snake_case ->
-        if is_snake_case?(string_field) do
-          string_field
-        else
-          camel_to_snake_case(string_field)
-        end
-
-      {module, function} ->
-        apply(module, function, [field_name])
-
-      {module, function, extra_args} ->
-        apply(module, function, [field_name | extra_args])
-
-      _ ->
-        raise ArgumentError, "Unsupported formatter: #{inspect(formatter)}"
-    end
-  end
-
-  defp is_camel_case?(string) do
-    # camelCase: starts with lowercase, no underscores, has at least one uppercase
-    String.match?(string, ~r/^[a-z][a-zA-Z0-9]*$/) && String.match?(string, ~r/[A-Z]/)
-  end
-
-  defp is_pascal_case?(string) do
-    # PascalCase: starts with uppercase, no underscores
-    String.match?(string, ~r/^[A-Z][a-zA-Z0-9]*$/)
-  end
-
-  defp is_snake_case?(string) do
-    # snake_case: lowercase with underscores, no uppercase
-    String.match?(string, ~r/^[a-z][a-z0-9_]*$/) && String.contains?(string, "_")
-  end
-
-  # Private helper for parsing field names from client format to internal format
-  defp parse_field_name(field_name, formatter) do
-    case formatter do
-      :camel_case ->
-        field_name |> to_string() |> camel_to_snake_case()
-
-      :pascal_case ->
-        field_name |> to_string() |> pascal_to_snake_case()
-
-      :snake_case ->
-        field_name |> to_string()
-
-      {module, function} ->
-        apply(module, function, [field_name])
-
-      {module, function, extra_args} ->
-        apply(module, function, [field_name | extra_args])
-
-      _ ->
-        raise ArgumentError, "Unsupported formatter: #{inspect(formatter)}"
     end
   end
 end

--- a/lib/ash_typescript/helpers.ex
+++ b/lib/ash_typescript/helpers.ex
@@ -5,49 +5,16 @@
 defmodule AshTypescript.Helpers do
   @moduledoc """
   Utility functions for string manipulation and transformations.
+
+  Case conversion functions are delegated to `AshIntrospection.Helpers`.
+  TypeScript-specific helper functions are defined here.
   """
-  def snake_to_pascal_case(snake) when is_atom(snake) do
-    snake
-    |> Atom.to_string()
-    |> snake_to_pascal_case()
-  end
 
-  def snake_to_pascal_case(snake) when is_binary(snake) do
-    Macro.camelize(snake)
-  end
-
-  def snake_to_camel_case(snake) when is_atom(snake) do
-    snake
-    |> Atom.to_string()
-    |> snake_to_camel_case()
-  end
-
-  def snake_to_camel_case(snake) when is_binary(snake) do
-    case Macro.camelize(snake) do
-      <<first::utf8, rest::binary>> -> String.downcase(<<first::utf8>>) <> rest
-      "" -> ""
-    end
-  end
-
-  def camel_to_snake_case(camel) when is_binary(camel) do
-    Macro.underscore(camel)
-  end
-
-  def camel_to_snake_case(camel) when is_atom(camel) do
-    camel
-    |> Atom.to_string()
-    |> camel_to_snake_case()
-  end
-
-  def pascal_to_snake_case(pascal) when is_atom(pascal) do
-    pascal
-    |> Atom.to_string()
-    |> pascal_to_snake_case()
-  end
-
-  def pascal_to_snake_case(pascal) when is_binary(pascal) do
-    Macro.underscore(pascal)
-  end
+  # Delegate case conversion functions to AshIntrospection
+  defdelegate snake_to_pascal_case(snake), to: AshIntrospection.Helpers
+  defdelegate snake_to_camel_case(snake), to: AshIntrospection.Helpers
+  defdelegate camel_to_snake_case(camel), to: AshIntrospection.Helpers
+  defdelegate pascal_to_snake_case(pascal), to: AshIntrospection.Helpers
 
   @doc """
   Formats a field name using the configured output field formatter for RPC.

--- a/lib/ash_typescript/type_system/introspection.ex
+++ b/lib/ash_typescript/type_system/introspection.ex
@@ -6,239 +6,27 @@ defmodule AshTypescript.TypeSystem.Introspection do
   @moduledoc """
   Core type introspection and classification for Ash types.
 
-  This module provides a centralized set of functions for determining the nature
-  and characteristics of Ash types, including embedded resources, typed structs,
-  unions, and primitive types.
-
-  Used throughout the codebase for type checking, code generation, and runtime
-  processing.
+  This module delegates to `AshIntrospection.TypeSystem.Introspection` for the core
+  functionality and provides TypeScript-specific extensions.
   """
 
-  @doc """
-  Checks if a module is an embedded Ash resource.
-
-  ## Examples
-
-      iex> AshTypescript.TypeSystem.Introspection.is_embedded_resource?(MyApp.Accounts.Address)
-      true
-
-      iex> AshTypescript.TypeSystem.Introspection.is_embedded_resource?(MyApp.Accounts.User)
-      false
-  """
-  def is_embedded_resource?(module) when is_atom(module) do
-    Ash.Resource.Info.resource?(module) and Ash.Resource.Info.embedded?(module)
-  end
-
-  def is_embedded_resource?(_), do: false
-
-  @doc """
-  Checks if a type is a primitive Ash type (not a complex or composite type).
-
-  Primitive types include basic types like String, Integer, Boolean, Date, UUID, etc.
-
-  ## Examples
-
-      iex> AshTypescript.TypeSystem.Introspection.is_primitive_type?(Ash.Type.String)
-      true
-
-      iex> AshTypescript.TypeSystem.Introspection.is_primitive_type?(Ash.Type.Union)
-      false
-  """
-  def is_primitive_type?(type) do
-    type in [
-      Ash.Type.Integer,
-      Ash.Type.String,
-      Ash.Type.Boolean,
-      Ash.Type.Float,
-      Ash.Type.Decimal,
-      Ash.Type.Date,
-      Ash.Type.DateTime,
-      Ash.Type.NaiveDatetime,
-      Ash.Type.UtcDatetime,
-      Ash.Type.Atom,
-      Ash.Type.UUID,
-      Ash.Type.Binary
-    ]
-  end
-
-  @doc """
-  Classifies an Ash type into a category for processing purposes.
-
-  Returns one of:
-  - `:union_attribute` - Union type
-  - `:embedded_resource` - Single embedded resource
-  - `:embedded_resource_array` - Array of embedded resources
-  - `:tuple` - Tuple type
-  - `:attribute` - Simple attribute (default)
-
-  ## Parameters
-  - `type_module` - The Ash type module (e.g., Ash.Type.String, Ash.Type.Union)
-  - `attribute` - The attribute struct containing type and constraints
-  - `is_array` - Whether this is inside an array type
-
-  ## Examples
-
-      iex> attr = %{type: MyApp.Address, constraints: []}
-      iex> AshTypescript.TypeSystem.Introspection.classify_ash_type(MyApp.Address, attr, false)
-      :embedded_resource
-  """
-  def classify_ash_type(type_module, _attribute, is_array) do
-    cond do
-      type_module == Ash.Type.Union ->
-        :union_attribute
-
-      is_embedded_resource?(type_module) ->
-        if is_array, do: :embedded_resource_array, else: :embedded_resource
-
-      type_module == Ash.Type.Tuple ->
-        :tuple
-
-      true ->
-        :attribute
-    end
-  end
-
-  @doc """
-  Extracts union types from an attribute's constraints.
-
-  Handles both direct union types and array union types.
-
-  ## Examples
-
-      iex> attr = %{type: Ash.Type.Union, constraints: [types: [note: [...], url: [...]]]}
-      iex> AshTypescript.TypeSystem.Introspection.get_union_types(attr)
-      [note: [...], url: [...]]
-  """
-  def get_union_types(attribute) do
-    get_union_types_from_constraints(attribute.type, attribute.constraints)
-  end
-
-  @doc """
-  Extracts union types from type and constraints directly.
-
-  Useful when you have constraints but not the full attribute struct.
-  Handles both direct union types and array union types.
-
-  ## Examples
-
-      iex> constraints = [types: [note: [...], url: [...]]]
-      iex> AshTypescript.TypeSystem.Introspection.get_union_types_from_constraints(Ash.Type.Union, constraints)
-      [note: [...], url: [...]]
-  """
-  def get_union_types_from_constraints(type, constraints) do
-    case type do
-      Ash.Type.Union ->
-        Keyword.get(constraints, :types, [])
-
-      {:array, Ash.Type.Union} ->
-        items_constraints = Keyword.get(constraints, :items, [])
-        Keyword.get(items_constraints, :types, [])
-
-      _ ->
-        []
-    end
-  end
-
-  @doc """
-  Extracts the inner type from an array type.
-
-  ## Examples
-
-      iex> AshTypescript.TypeSystem.Introspection.get_inner_type({:array, Ash.Type.String})
-      Ash.Type.String
-
-      iex> AshTypescript.TypeSystem.Introspection.get_inner_type(Ash.Type.String)
-      Ash.Type.String
-  """
-  def get_inner_type({:array, inner_type}), do: inner_type
-  def get_inner_type(type), do: type
-
-  @doc """
-  Checks if a type is an Ash type module.
-
-  ## Examples
-
-      iex> AshTypescript.TypeSystem.Introspection.is_ash_type?(Ash.Type.String)
-      true
-
-      iex> AshTypescript.TypeSystem.Introspection.is_ash_type?(MyApp.CustomType)
-      true
-
-      iex> AshTypescript.TypeSystem.Introspection.is_ash_type?(:string)
-      false
-  """
-  def is_ash_type?(module) when is_atom(module) do
-    Ash.Type.ash_type?(module)
-  rescue
-    _ -> false
-  end
-
-  def is_ash_type?(_), do: false
+  # Delegate all core functions to AshIntrospection
+  defdelegate is_embedded_resource?(module), to: AshIntrospection.TypeSystem.Introspection
+  defdelegate is_primitive_type?(type), to: AshIntrospection.TypeSystem.Introspection
+  defdelegate classify_ash_type(type_module, attribute, is_array), to: AshIntrospection.TypeSystem.Introspection
+  defdelegate get_union_types(attribute), to: AshIntrospection.TypeSystem.Introspection
+  defdelegate get_union_types_from_constraints(type, constraints), to: AshIntrospection.TypeSystem.Introspection
+  defdelegate get_inner_type(type), to: AshIntrospection.TypeSystem.Introspection
+  defdelegate is_ash_type?(module), to: AshIntrospection.TypeSystem.Introspection
 
   @doc """
   Recursively unwraps Ash.Type.NewType to get the underlying type and constraints.
 
-  When a type is wrapped in one or more NewType wrappers, this function
-  recursively unwraps them until it reaches the base type. If the NewType
-  has a `typescript_field_names/0` callback and the constraints don't already
-  have an `instance_of` key, it will add the NewType module as `instance_of`
-  to preserve the reference for field name mapping.
-
-  ## Parameters
-  - `type` - The type to unwrap (e.g., MyApp.CustomType)
-  - `constraints` - The constraints for the type
-
-  ## Returns
-  A tuple `{unwrapped_type, unwrapped_constraints}` where:
-  - `unwrapped_type` is the final underlying type after all NewType unwrapping
-  - `unwrapped_constraints` are the final constraints, potentially augmented with `instance_of`
-
-  ## Examples
-
-      iex> # Simple NewType with typescript_field_names
-      iex> unwrap_new_type(MyApp.TaskStats, [])
-      {Ash.Type.Struct, [fields: [...], instance_of: MyApp.TaskStats]}
-
-      iex> # Nested NewTypes (outermost with callback wins)
-      iex> unwrap_new_type(MyApp.Wrapper, [])
-      {Ash.Type.String, [max_length: 100, instance_of: MyApp.Wrapper]}
-
-      iex> # Non-NewType (returns unchanged)
-      iex> unwrap_new_type(Ash.Type.String, [max_length: 50])
-      {Ash.Type.String, [max_length: 50]}
+  Uses :typescript_field_names as the callback to check for field name mappings.
   """
-  def unwrap_new_type(type, constraints) when is_atom(type) do
-    if Ash.Type.NewType.new_type?(type) do
-      subtype = Ash.Type.NewType.subtype_of(type)
-
-      # Get constraints from the NewType
-      # Ash.Type.NewType.constraints/2 only returns passed constraints when lazy_init? is false,
-      # but do_init/1 returns the full merged constraints including subtype_constraints
-      constraints =
-        case type.do_init(constraints) do
-          {:ok, merged_constraints} -> merged_constraints
-          {:error, _} -> constraints
-        end
-
-      # Preserve reference to outermost NewType with typescript_field_names
-      # Only add instance_of if:
-      # 1. This NewType has typescript_field_names callback
-      # 2. Constraints don't already have instance_of (preserves outermost)
-      augmented_constraints =
-        if function_exported?(type, :typescript_field_names, 0) and
-             not Keyword.has_key?(constraints, :instance_of) do
-          Keyword.put(constraints, :instance_of, type)
-        else
-          constraints
-        end
-
-      {subtype, augmented_constraints}
-    else
-      {type, constraints}
-    end
+  def unwrap_new_type(type, constraints) do
+    AshIntrospection.TypeSystem.Introspection.unwrap_new_type(type, constraints, :typescript_field_names)
   end
-
-  def unwrap_new_type(type, constraints), do: {type, constraints}
 
   @doc """
   Checks if a type is a custom Ash type with a typescript_type_name callback.

--- a/mix.exs
+++ b/mix.exs
@@ -166,6 +166,7 @@ defmodule AshTypescript.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:ash_introspection, path: "../ash_introspection"},
       {:ash, "~> 3.7"},
       {:ash_phoenix, "~> 2.0"},
       {:ash_postgres, "~> 2.0", only: [:dev, :test]},


### PR DESCRIPTION
## Summary
- Extracts shared introspection utilities (type introspection, field formatting, case conversion helpers) to a new `ash_introspection` package
- Delegates `AshTypescript.FieldFormatter`, `AshTypescript.Helpers`, and `AshTypescript.TypeSystem.Introspection` to the shared package
- Enables code reuse across Ash ecosystem packages (e.g., ash_typescript, ash_json_api)

## Changes
- `lib/ash_typescript/field_formatter.ex` - Now delegates to `AshIntrospection.FieldFormatter`
- `lib/ash_typescript/helpers.ex` - Case conversion functions delegate to `AshIntrospection.Helpers`
- `lib/ash_typescript/type_system/introspection.ex` - Core introspection delegates to `AshIntrospection.TypeSystem.Introspection`
- `mix.exs` - Added `ash_introspection` dependency

## Test plan
- [ ] Verify existing tests pass with delegated implementations
- [ ] Ensure backwards compatibility of public API