### PR TITLE
fix: handle list input in ErrorBuilder.build_error_response/1

### DIFF
--- a/lib/ash_typescript/rpc/error_builder.ex
+++ b/lib/ash_typescript/rpc/error_builder.ex
@@ -564,6 +564,14 @@ defmodule AshTypescript.Rpc.ErrorBuilder do
           }
         }
 
+      # === LIST OF ERRORS (e.g. from Ash.bulk_update BulkResult) ===
+
+      errors when is_list(errors) ->
+        Enum.flat_map(errors, fn error ->
+          result = build_error_response(error)
+          if is_list(result), do: result, else: [result]
+        end)
+
       # === ASH FRAMEWORK ERRORS ===
 
       # Any exception or Ash error - convert to Ash error class and process


### PR DESCRIPTION
Bulk operations return errors as a list, which previously fell through
to the catch-all clause losing the actual error messages. Add a list
clause that recursively processes and flattens each element.
