### PR TITLE
fix: stabilize TS field order for :auto calcs with literal map exprs

### DIFF
--- a/lib/ash_typescript/codegen/helpers.ex
+++ b/lib/ash_typescript/codegen/helpers.ex
@@ -57,6 +57,48 @@ defmodule AshTypescript.Codegen.Helpers do
   def is_complex_return_type(Ash.Type.Tuple, _constraints), do: true
   def is_complex_return_type(_, _), do: false
 
+  # Sort the `:fields` entry of a typed-map/struct constraint list
+  # alphabetically by key.
+  #
+  # Why: `:auto`-typed calcs use Ash's expression-to-type resolver, which
+  # materializes literal map exprs (`expr(%{a: id, b: name})`) through a
+  # runtime Erlang map. Map iteration order depends on atom term ordering,
+  # which varies between BEAM loads (e.g. warm `_build/dev` vs clean
+  # `_build/test`). Left unsorted, the emitted TypeScript would reshuffle
+  # across compiles. TS field order is cosmetic, so alphabetical is fine.
+  #
+  # How to apply: call only on constraints derived from an `:auto` calc
+  # (calcs whose `calculation` is `Ash.Resource.Calculation.Expression`, or
+  # publications whose `transform:` resolves to such a calc). Other
+  # `:fields` lists come from user DSL and already have a stable order.
+  def sort_auto_fields(constraints) when is_list(constraints) do
+    case Keyword.fetch(constraints, :fields) do
+      {:ok, fields} when is_list(fields) ->
+        sorted = Enum.sort_by(fields, fn {name, _} -> Atom.to_string(name) end)
+        Keyword.put(constraints, :fields, sorted)
+
+      _ ->
+        constraints
+    end
+  end
+
+  def sort_auto_fields(constraints), do: constraints
+
+  # Returns `calc.constraints` with `:fields` sorted when the calculation
+  # is expression-based (the only source of non-deterministic map-literal
+  # field ordering). For all other calcs, returns constraints unchanged.
+  def auto_safe_calc_constraints(
+        %Ash.Resource.Calculation{
+          calculation: {Ash.Resource.Calculation.Expression, _}
+        } = calc
+      ) do
+    sort_auto_fields(calc.constraints || [])
+  end
+
+  def auto_safe_calc_constraints(%Ash.Resource.Calculation{} = calc) do
+    calc.constraints || []
+  end
+
   @doc """
   Looks up the type of an aggregate field by traversing relationship paths.
   """

--- a/lib/ash_typescript/codegen/resource_schemas.ex
+++ b/lib/ash_typescript/codegen/resource_schemas.ex
@@ -794,7 +794,10 @@ defmodule AshTypescript.Codegen.ResourceSchemas do
           end
 
         _ ->
-          TypeMapper.get_ts_type(calc)
+          TypeMapper.get_ts_type(%{
+            type: calc.type,
+            constraints: Helpers.auto_safe_calc_constraints(calc)
+          })
       end
 
     if allow_nil? do

--- a/lib/ash_typescript/codegen/type_mapper.ex
+++ b/lib/ash_typescript/codegen/type_mapper.ex
@@ -782,7 +782,7 @@ defmodule AshTypescript.Codegen.TypeMapper do
             AshTypescript.Rpc.output_field_formatter()
           )
 
-        ts_type = map_type(calc.type, calc.constraints, :output)
+        ts_type = map_type(calc.type, Helpers.auto_safe_calc_constraints(calc), :output)
 
         if calc.allow_nil? do
           "  #{formatted_field}: #{ts_type} | null;"

--- a/lib/ash_typescript/typed_channel/codegen.ex
+++ b/lib/ash_typescript/typed_channel/codegen.ex
@@ -48,7 +48,7 @@ defmodule AshTypescript.TypedChannel.Codegen do
       export function unsubscribeOrgChannel(channel: OrgChannel, refs: OrgChannelRefs): void { ... }
   """
 
-  alias AshTypescript.Codegen.TypeMapper
+  alias AshTypescript.Codegen.{Helpers, TypeMapper}
   alias AshTypescript.TypedChannel.Info
 
   @doc """
@@ -242,10 +242,21 @@ defmodule AshTypescript.TypedChannel.Codegen do
 
   defp resolve_payload_type(%{returns: returns} = pub, _resource_module)
        when not is_nil(returns) do
-    TypeMapper.map_channel_payload_type(returns, pub.constraints || [])
+    TypeMapper.map_channel_payload_type(returns, pub_constraints(pub))
   end
 
   defp resolve_payload_type(_, _), do: "unknown"
+
+  # When a publication derives its return type via `transform :some_calc`
+  # (atom transform), Ash copies the calc's type+constraints onto the pub.
+  # For `:auto`-typed calcs this copy includes a non-deterministically
+  # ordered `:fields` list — sort it here to stabilize TS output.
+  defp pub_constraints(%{transform: transform, constraints: constraints})
+       when is_atom(transform) and not is_nil(transform) do
+    Helpers.sort_auto_fields(constraints || [])
+  end
+
+  defp pub_constraints(%{constraints: constraints}), do: constraints || []
 
   defp build_channel_brand_type(channel_name) do
     """

--- a/test/ash_typescript/codegen/auto_calc_field_order_test.exs
+++ b/test/ash_typescript/codegen/auto_calc_field_order_test.exs
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2025 ash_typescript contributors <https://github.com/ash-project/ash_typescript/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshTypescript.Codegen.AutoCalcFieldOrderTest do
+  @moduledoc """
+  Regression: `:auto`-typed calculations with literal-map expressions must
+  emit a stable, deterministic TypeScript field order across compiles.
+
+  Ash resolves `expr(%{a: ..., b: ...})` through a runtime Erlang map whose
+  iteration order depends on atom term ordering at BEAM load time (warm
+  `_build/dev` vs clean `_build/test` can differ). Without a local sort
+  this leaks into generated TS as non-deterministic field order. The fix
+  is narrow: sort only at calc- and publication-introspection sites that
+  carry auto-derived constraints — user-declared typed maps are unaffected.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshTypescript.Codegen.Helpers
+  alias AshTypescript.Codegen.TypeMapper
+
+  @moduletag :ash_typescript
+
+  describe "Helpers.sort_auto_fields/1" do
+    test "sorts :fields alphabetically by key" do
+      constraints = [
+        fields: [
+          z: [type: :string],
+          a: [type: :integer],
+          m: [type: :boolean]
+        ]
+      ]
+
+      sorted = Helpers.sort_auto_fields(constraints)
+
+      assert sorted |> Keyword.fetch!(:fields) |> Keyword.keys() == [:a, :m, :z]
+    end
+
+    test "yields identical output regardless of input order" do
+      base = %{
+        z: [type: :string],
+        a: [type: :integer],
+        m: [type: :boolean]
+      }
+
+      variants = [
+        [z: base.z, a: base.a, m: base.m],
+        [a: base.a, z: base.z, m: base.m],
+        [m: base.m, z: base.z, a: base.a]
+      ]
+
+      outputs =
+        Enum.map(variants, fn fields ->
+          Helpers.sort_auto_fields(fields: fields)
+        end)
+
+      assert outputs |> Enum.uniq() |> length() == 1
+    end
+
+    test "passes constraints without :fields through unchanged" do
+      assert Helpers.sort_auto_fields([]) == []
+
+      assert Helpers.sort_auto_fields(instance_of: SomeModule) ==
+               [instance_of: SomeModule]
+    end
+  end
+
+  describe "Helpers.auto_safe_calc_constraints/1" do
+    test "sorts fields for expression-based calcs" do
+      calc =
+        calc_fixture(
+          fields: shuffled_fields(),
+          calculation: {Ash.Resource.Calculation.Expression, [expr: nil]}
+        )
+
+      fields =
+        calc
+        |> Helpers.auto_safe_calc_constraints()
+        |> Keyword.fetch!(:fields)
+
+      assert Keyword.keys(fields) == [:a, :m, :z]
+    end
+
+    test "leaves non-expression calcs untouched (preserves user-declared order)" do
+      calc =
+        calc_fixture(
+          fields: shuffled_fields(),
+          calculation: {__MODULE__.FakeCustomCalc, []}
+        )
+
+      fields =
+        calc
+        |> Helpers.auto_safe_calc_constraints()
+        |> Keyword.fetch!(:fields)
+
+      assert Keyword.keys(fields) == [:z, :a, :m]
+    end
+  end
+
+  describe "map_type/3 through auto-safe helper produces stable output" do
+    test "byte-identical TS across shuffled synthetic constraints" do
+      variants = [
+        [
+          z: [type: Ash.Type.UUID, allow_nil?: false],
+          a: [type: Ash.Type.String, allow_nil?: false],
+          m: [type: Ash.Type.String, allow_nil?: false]
+        ],
+        [
+          a: [type: Ash.Type.String, allow_nil?: false],
+          z: [type: Ash.Type.UUID, allow_nil?: false],
+          m: [type: Ash.Type.String, allow_nil?: false]
+        ],
+        [
+          m: [type: Ash.Type.String, allow_nil?: false],
+          z: [type: Ash.Type.UUID, allow_nil?: false],
+          a: [type: Ash.Type.String, allow_nil?: false]
+        ]
+      ]
+
+      outputs =
+        Enum.map(variants, fn fields ->
+          calc =
+            calc_fixture(
+              fields: fields,
+              calculation: {Ash.Resource.Calculation.Expression, [expr: nil]}
+            )
+
+          constraints = Helpers.auto_safe_calc_constraints(calc)
+          TypeMapper.map_type(calc.type, constraints, :output)
+        end)
+
+      assert outputs |> Enum.uniq() |> length() == 1,
+             "expected byte-identical TS for shuffled inputs, got: #{inspect(outputs)}"
+
+      [single] = Enum.uniq(outputs)
+      # :a before :m before :z
+      assert String.match?(single, ~r/\{a:.*m:.*z:/)
+    end
+  end
+
+  describe "full typed-channel codegen for :auto map calc" do
+    test "TrackerOrderedCardPayload emits fields in alphabetical order" do
+      content =
+        AshTypescript.TypedChannel.Codegen.generate_channel_types(
+          AshTypescript.Test.TrackerChannel,
+          "tracker:*"
+        )
+
+      line =
+        content
+        |> String.split("\n")
+        |> Enum.find(&String.contains?(&1, "TrackerOrderedCardPayload"))
+
+      assert line, "expected a TrackerOrderedCardPayload line in generated TS"
+
+      assert line =~
+               ~r/export type TrackerOrderedCardPayload = \{a: [^,]+, m: [^,]+, z: [^}]+\};/
+    end
+  end
+
+  defmodule FakeCustomCalc do
+    @moduledoc false
+  end
+
+  defp shuffled_fields do
+    [
+      z: [type: :string],
+      a: [type: :integer],
+      m: [type: :boolean]
+    ]
+  end
+
+  defp calc_fixture(opts) do
+    %Ash.Resource.Calculation{
+      name: :fixture,
+      type: Ash.Type.Map,
+      constraints: [fields: Keyword.fetch!(opts, :fields)],
+      calculation: Keyword.fetch!(opts, :calculation),
+      allow_nil?: false,
+      arguments: [],
+      description: nil,
+      load: [],
+      public?: true,
+      sortable?: true,
+      filterable?: true,
+      sensitive?: false,
+      async?: false,
+      field?: true,
+      multitenancy: nil,
+      __spark_metadata__: nil
+    }
+  end
+end

--- a/test/ash_typescript/typed_channel/codegen_test.exs
+++ b/test/ash_typescript/typed_channel/codegen_test.exs
@@ -317,9 +317,10 @@ defmodule AshTypescript.TypedChannel.CodegenTest do
       types_content: content
     } do
       # %{id: id, name: name, latest_entry_body: first(entries, :body)}
-      # id non-null, name nullable, first() nullable
+      # Fields emitted alphabetically by source key (id, latest_entry_body, name)
+      # to keep TS stable across non-deterministic Ash :auto field ordering.
       assert content =~
-               "export type TrackerDetailPayload = {id: UUID, name: string | null, latestEntryBody: string | null};"
+               "export type TrackerDetailPayload = {id: UUID, latestEntryBody: string | null, name: string | null};"
     end
 
     test "integer calc payload type (count aggregate)", %{types_content: content} do
@@ -335,17 +336,19 @@ defmodule AshTypescript.TypedChannel.CodegenTest do
     end
 
     test "map with nested relationship fields (first on related FK)", %{types_content: content} do
-      # id non-null (PK), name nullable, aggregates (first) nullable
+      # id non-null (PK), name nullable, aggregates (first) nullable.
+      # Fields emitted alphabetically by source key.
       assert content =~
-               "export type TrackerDeepDetailPayload = {id: UUID, name: string | null, latestAuthor: UUID | null, latestBody: string | null, latestScore: number | null};"
+               "export type TrackerDeepDetailPayload = {id: UUID, latestAuthor: UUID | null, latestBody: string | null, latestScore: number | null, name: string | null};"
     end
 
     test "map mixing aggregates, booleans, and strings with correct nullability", %{
       types_content: content
     } do
-      # all fields nullable: attributes nullable, aggregates nullable, boolean expr with nullable operands nullable
+      # all fields nullable: attributes nullable, aggregates nullable, boolean expr
+      # with nullable operands nullable. Fields emitted alphabetically by source key.
       assert content =~
-               "export type TrackerReportPayload = {name: string | null, status: string | null, entryCount: number | null, isActive: boolean | null, topScore: number | null, latestBody: string | null};"
+               "export type TrackerReportPayload = {entryCount: number | null, isActive: boolean | null, latestBody: string | null, name: string | null, status: string | null, topScore: number | null};"
     end
 
     test "no payload types are unknown", %{types_content: content} do

--- a/test/support/resources/channel_tracker.ex
+++ b/test/support/resources/channel_tracker.ex
@@ -52,6 +52,13 @@ defmodule AshTypescript.Test.ChannelTracker do
       public?: true,
       transform: :snapshot
 
+    # :auto map calc with deliberately-non-alphabetic source keys —
+    # used to verify deterministic TS field ordering.
+    publish :ordered_card, [:id],
+      event: "tracker_ordered_card",
+      public?: true,
+      transform: :ordered_card
+
     # Map calc with relationship traversal (:auto typed)
     publish :detail_snapshot, [:id],
       event: "tracker_detail",
@@ -158,6 +165,12 @@ defmodule AshTypescript.Test.ChannelTracker do
       public?(true)
     end
 
+    # :auto map whose source keys are deliberately not in alphabetic order —
+    # used to verify deterministic (sorted) TypeScript field emission.
+    calculate :ordered_card, :auto, expr(%{z: id, a: name, m: status}) do
+      public?(true)
+    end
+
     # :auto map mixing different expression types in a single map
     calculate :report,
               :auto,
@@ -177,6 +190,10 @@ defmodule AshTypescript.Test.ChannelTracker do
     defaults [:read, :create, :update, :destroy]
 
     update :snapshot do
+      accept []
+    end
+
+    update :ordered_card do
       accept []
     end
 

--- a/test/support/resources/tracker_channel.ex
+++ b/test/support/resources/tracker_channel.ex
@@ -21,6 +21,7 @@ defmodule AshTypescript.Test.TrackerChannel do
       publish(:tracker_label)
       publish(:tracker_status_changed)
       publish(:tracker_snapshot)
+      publish(:tracker_ordered_card)
       publish(:tracker_detail)
       publish(:tracker_entry_count)
       publish(:tracker_is_active)


### PR DESCRIPTION
## Summary

- `:auto`-typed Ash calculations with literal map expressions (e.g. `calculate :summary, :auto, expr(%{a: id, b: name})`) emit TypeScript interfaces whose field order changes non-deterministically between compiles. Ash materializes the literal map through a runtime Erlang map whose iteration order depends on atom term ordering at BEAM load time — so warm `_build/dev` and clean `_build/test` can disagree. This manifests as flaky snapshot diffs and unstable generated TS.
- Fix is local to ash_typescript: sort `:fields` alphabetically at the calc- and publication-introspection sites known to carry auto-derived constraints. User-declared typed maps (`attribute :foo, :map, constraints: [fields: [...]]`) pass through unchanged — their source order is preserved by the DSL and was already deterministic.

## Changes

- **`lib/ash_typescript/codegen/helpers.ex`** — Adds `sort_auto_fields/1` and `auto_safe_calc_constraints/1`. The latter only sorts when the calc is expression-based (`calc.calculation = {Ash.Resource.Calculation.Expression, _}`) — the sole source of non-determinism.
- **`lib/ash_typescript/codegen/type_mapper.ex`** — Wraps `calc.constraints` through the helper in the `%Ash.Resource.Calculation{}` schema-emission branch.
- **`lib/ash_typescript/codegen/resource_schemas.ex`** — Same treatment in `get_calculation_return_type_for_metadata/2`.
- **`lib/ash_typescript/typed_channel/codegen.ex`** — When a pub's `transform:` is a calc-name atom (meaning Ash derived `returns`/`constraints` from a calc), sort fields via `sort_auto_fields/1` before passing to `map_channel_payload_type/2`.
- **Tests** — New `test/ash_typescript/codegen/auto_calc_field_order_test.exs` covers:
  - Unit tests documenting the helper contracts.
  - A byte-identical property test that feeds three shuffled synthetic `:fields` orderings through `auto_safe_calc_constraints/1` + `map_type/3` and asserts identical output.
  - An end-to-end typed-channel codegen test asserting `TrackerOrderedCardPayload` emits alphabetically sorted fields.

  Caveat on detection power: because the non-determinism lives upstream in Ash's expression-to-type resolver, we can't force a reliably non-alphabetical input from a test. These tests verify the fix's contract and post-fix behavior; they don't guarantee to fail on every pre-fix BEAM load for every input.

  Three existing assertions in `typed_channel/codegen_test.exs` locked in source order for `TrackerDetailPayload`, `TrackerDeepDetailPayload`, and `TrackerReportPayload` and have been updated to the new alphabetical order.

## Why the fix lives here

The upstream root cause is in Ash's `determine_type` path — resolving a map literal expr into `{Ash.Type.Map, fields: [...]}`. Fixing it there would require either a new expression-tree struct (propagates to `ash_postgres` and every other data layer) or a side-channel for ordering through the DSL pipeline. Neither is worth it to give one consumer (codegen) a stable input. Since TypeScript field order is purely cosmetic, alphabetizing at the ash_typescript consumer is the right layer.

## Test plan

- [x] `mix test` — 2226 tests, 0 failures
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [x] User-declared typed-map field ordering preserved (`auto_safe_calc_constraints/1` only sorts for expression-based calcs)