### PR TITLE
fix(codegen): add type alias clause for Ash.Type.Vector

### DIFF
--- a/lib/ash_typescript/codegen/type_aliases.ex
+++ b/lib/ash_typescript/codegen/type_aliases.ex
@@ -136,6 +136,7 @@ defmodule AshTypescript.Codegen.TypeAliases do
   defp generate_ash_type_alias(Ash.Type.Duration), do: "export type Duration = string;"
   defp generate_ash_type_alias(Ash.Type.DurationName), do: "export type DurationName = string;"
   defp generate_ash_type_alias(Ash.Type.Binary), do: "export type Binary = string;"
+  defp generate_ash_type_alias(Ash.Type.Vector), do: "export type Vector = number[];"
 
   defp generate_ash_type_alias(Ash.Type.UrlEncodedBinary),
     do: "export type UrlEncodedBinary = string;"

--- a/test/ash_typescript/codegen/type_aliases_test.exs
+++ b/test/ash_typescript/codegen/type_aliases_test.exs
@@ -55,4 +55,17 @@ defmodule AshTypescript.Codegen.TypeAliasesTest do
       assert is_binary(result)
     end
   end
+
+  describe "Ash.Type.Vector" do
+    test "generates Vector type alias for resources with vector attributes" do
+      # VectorAttributeFixture has a single :embedding attribute of type Ash.Type.Vector.
+
+      resources = [AshTypescript.Test.VectorAttributeFixture]
+      actions = []
+
+      result = TypeAliases.generate_ash_type_aliases(resources, actions, :ash_typescript)
+
+      assert result =~ "export type Vector = number[];"
+    end
+  end
 end

--- a/test/support/resources/vector_attribute_fixture.ex
+++ b/test/support/resources/vector_attribute_fixture.ex
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 ash_typescript contributors <https://github.com/ash-project/ash_typescript/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshTypescript.Test.VectorAttributeFixture do
+  @moduledoc """
+  Resource with a single Ash.Type.Vector attribute for type alias testing.
+  """
+  use Ash.Resource, domain: nil, data_layer: Ash.DataLayer.Ets
+
+  attributes do
+    uuid_primary_key :id
+    attribute :embedding, Ash.Type.Vector, public?: true
+  end
+
+  actions do
+    defaults [:read, :create]
+  end
+end


### PR DESCRIPTION
## Summary

`Ash.Type.Vector` is mapped consistently across three places in `ash_typescript` today:

- `lib/ash_typescript/codegen/type_mapper.ex:43` → `"number[]"`
- `lib/ash_typescript/codegen/valibot_schema_generator.ex:55` → `"v.array(v.number())"`
- `lib/ash_typescript/codegen/zod_schema_generator.ex:55` → `"z.array(z.number())"`

And `test/ash_typescript/typescript_codegen_test.exs:54` asserts:

```elixir
assert Codegen.get_ts_type(%{type: Ash.Type.Vector}) == "number[]"
```

But `lib/ash_typescript/codegen/type_aliases.ex` is missing a clause for `Ash.Type.Vector`. When a project's resources use a Vector attribute (e.g. for pgvector embeddings), `generate_ash_type_aliases/3` reaches the catch-all and raises `Unknown type: Elixir.Ash.Type.Vector` — blocking `mix ash.codegen` entirely.

This PR adds the missing clause to match the existing treatment, plus a regression test using a minimal fixture resource with a single Vector attribute.

## Encountered

Running `mix ash.codegen` against a project where 16 resources carry Vector attributes for embedding fields. Codegen consistently failed until `config :ash_typescript, :type_mapping_overrides, [{Ash.Type.Vector, "number[]"}]` was added as a workaround.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
