### PR TITLE
fix: preserve false values when extracting plain map fields

### DIFF
--- a/lib/ash_typescript/rpc/result_processor.ex
+++ b/lib/ash_typescript/rpc/result_processor.ex
@@ -483,9 +483,6 @@ defmodule AshTypescript.Rpc.ResultProcessor do
     end)
   end
 
-  # `Map.get(map, atom) || Map.get(map, string)` would discard legitimate
-  # `false` (and `nil`) values - the only falsy values in Elixir - so fall
-  # back to the string key only when the atom key is absent.
   defp plain_map_field(map, field_atom) do
     case Map.fetch(map, field_atom) do
       {:ok, value} -> value

--- a/lib/ash_typescript/rpc/result_processor.ex
+++ b/lib/ash_typescript/rpc/result_processor.ex
@@ -462,11 +462,11 @@ defmodule AshTypescript.Rpc.ResultProcessor do
     Enum.reduce(template, %{}, fn field_spec, acc ->
       case field_spec do
         field_atom when is_atom(field_atom) ->
-          field_value = Map.get(value, field_atom) || Map.get(value, to_string(field_atom))
+          field_value = plain_map_field(value, field_atom)
           Map.put(acc, field_atom, normalize_primitive(field_value))
 
         {field_atom, nested_template} when is_atom(field_atom) ->
-          field_value = Map.get(value, field_atom) || Map.get(value, to_string(field_atom))
+          field_value = plain_map_field(value, field_atom)
 
           nested_extracted =
             if is_map(field_value) and nested_template != [] do
@@ -481,6 +481,16 @@ defmodule AshTypescript.Rpc.ResultProcessor do
           acc
       end
     end)
+  end
+
+  # `Map.get(map, atom) || Map.get(map, string)` would discard legitimate
+  # `false` (and `nil`) values - the only falsy values in Elixir - so fall
+  # back to the string key only when the atom key is absent.
+  defp plain_map_field(map, field_atom) do
+    case Map.fetch(map, field_atom) do
+      {:ok, value} -> value
+      :error -> Map.get(map, to_string(field_atom))
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────────────────

--- a/test/ash_typescript/rpc/result_processor_plain_map_test.exs
+++ b/test/ash_typescript/rpc/result_processor_plain_map_test.exs
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 ash_typescript contributors <https://github.com/ash-project/ash_typescript/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshTypescript.Rpc.ResultProcessorPlainMapTest do
+  use ExUnit.Case, async: true
+
+  alias AshTypescript.Rpc.ResultProcessor
+
+  describe "plain map extraction (untyped maps with a field template)" do
+    test "preserves false values under atom keys" do
+      assert %{enabled: false} =
+               ResultProcessor.extract_value(%{enabled: false}, nil, [], [:enabled])
+    end
+
+    test "preserves false values under string keys" do
+      assert %{enabled: false} =
+               ResultProcessor.extract_value(%{"enabled" => false}, nil, [], [:enabled])
+    end
+
+    test "preserves false values in nested templates" do
+      assert %{settings: %{enabled: false}} =
+               ResultProcessor.extract_value(
+                 %{settings: %{enabled: false}},
+                 nil,
+                 [],
+                 [{:settings, [:enabled]}]
+               )
+    end
+
+    test "missing atom key still falls back to the string key" do
+      assert %{count: 3} =
+               ResultProcessor.extract_value(%{"count" => 3}, nil, [], [:count])
+    end
+  end
+end


### PR DESCRIPTION
We fix a bug that would pass false values as nil to the RPC
-----AI BELOW------

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes #78

`extract_plain_map_value/2` read fields with `Map.get(value, field_atom) || Map.get(value, to_string(field_atom))`, which discards legitimate `false` values — so generic actions returning `:map` with a boolean field holding `false` produced `null` in RPC responses.

The fix falls back to the string key only when the atom key is absent (`Map.fetch/2`), at both call sites.

New unit tests cover `false` under atom keys, string keys, and nested templates; the two `false` tests fail without the lib change. Full suite passes (2237 tests).

_Prepared with AI assistance (Claude); reproduced, fix verified red/green against main, vetted by me._
