### PR TITLE
fix: derive aggregate output nullability from the kind's default, not include_nil?

### DIFF
--- a/lib/ash_typescript/codegen/helpers.ex
+++ b/lib/ash_typescript/codegen/helpers.ex
@@ -84,13 +84,22 @@ defmodule AshTypescript.Codegen.Helpers do
 
   An aggregate falls back to a default when the relationship yields no rows, so
   nullability is exactly "is there a default to fall back to?". `count` defaults
-  to `0` and `list` to `[]`, so they are never `nil`; `avg`, `first`, `sum`,
-  `min` and `max` default to `nil`. An explicit `default` on the aggregate
-  overrides the kind's default and makes it non-nullable.
+  to `0`, `list` to `[]` and `exists` to `false`, so they are never `nil`; `avg`,
+  `first`, `sum`, `min`, `max` and `custom` default to `nil`. An explicit
+  `default` on the aggregate overrides the kind's default and makes it
+  non-nullable.
   """
   def aggregate_allow_nil?(%Ash.Resource.Aggregate{} = aggregate) do
-    is_nil(aggregate.default) and is_nil(Ash.Query.Aggregate.default_value(aggregate.kind))
+    is_nil(aggregate.default) and is_nil(kind_default(aggregate.kind))
   end
+
+  # `Ash.Query.Aggregate.default_value/1` reports `nil` for `:exists`, but that
+  # default is never reached: an exists aggregate is a boolean predicate, and the
+  # data layer yields `false` — not `nil` — when nothing matches. Deriving
+  # nullability from `default_value/1` alone would type every `exists` as
+  # `boolean | null` and break every existing consumer of one.
+  defp kind_default(:exists), do: false
+  defp kind_default(kind), do: Ash.Query.Aggregate.default_value(kind)
 
   @doc """
   Converts a PascalCase name to camelCase by lowercasing the first character.

--- a/lib/ash_typescript/codegen/helpers.ex
+++ b/lib/ash_typescript/codegen/helpers.ex
@@ -74,6 +74,25 @@ defmodule AshTypescript.Codegen.Helpers do
   end
 
   @doc """
+  Determines whether an aggregate's value can be `nil` in a response.
+
+  This is deliberately *not* `include_nil?`. That option controls whether `nil`
+  values in the **source** rows take part in the computation (e.g. whether a
+  `count` counts related rows whose field is `nil`); it says nothing about
+  whether the aggregate itself can return `nil`, and it defaults to `false`,
+  which would type every aggregate as non-nullable.
+
+  An aggregate falls back to a default when the relationship yields no rows, so
+  nullability is exactly "is there a default to fall back to?". `count` defaults
+  to `0` and `list` to `[]`, so they are never `nil`; `avg`, `first`, `sum`,
+  `min` and `max` default to `nil`. An explicit `default` on the aggregate
+  overrides the kind's default and makes it non-nullable.
+  """
+  def aggregate_allow_nil?(%Ash.Resource.Aggregate{} = aggregate) do
+    is_nil(aggregate.default) and is_nil(Ash.Query.Aggregate.default_value(aggregate.kind))
+  end
+
+  @doc """
   Converts a PascalCase name to camelCase by lowercasing the first character.
 
   ## Examples

--- a/lib/ash_typescript/codegen/resource_schemas.ex
+++ b/lib/ash_typescript/codegen/resource_schemas.ex
@@ -465,8 +465,8 @@ defmodule AshTypescript.Codegen.ResourceSchemas do
     end
   end
 
-  defp allow_nil?(%{include_nil?: include_nil?}) do
-    include_nil?
+  defp allow_nil?(%Ash.Resource.Aggregate{} = aggregate) do
+    Helpers.aggregate_allow_nil?(aggregate)
   end
 
   defp allow_nil?(%{allow_nil?: allow_nil?}) do

--- a/lib/ash_typescript/codegen/type_mapper.ex
+++ b/lib/ash_typescript/codegen/type_mapper.ex
@@ -818,7 +818,7 @@ defmodule AshTypescript.Codegen.TypeMapper do
             AshTypescript.Rpc.output_field_formatter()
           )
 
-        if agg.include_nil? do
+        if Helpers.aggregate_allow_nil?(agg) do
           "  #{formatted_field}: #{type} | null;"
         else
           "  #{formatted_field}: #{type};"

--- a/test/ash_typescript/typescript_codegen_test.exs
+++ b/test/ash_typescript/typescript_codegen_test.exs
@@ -426,7 +426,7 @@ defmodule AshTypescript.CodegenTest do
                })
       end
 
-      for kind <- [:count, :list] do
+      for kind <- [:count, :list, :exists] do
         refute Helpers.aggregate_allow_nil?(%Ash.Resource.Aggregate{
                  kind: kind,
                  include_nil?: false
@@ -437,6 +437,18 @@ defmodule AshTypescript.CodegenTest do
                  include_nil?: true
                })
       end
+    end
+
+    test "exists is never nullable, despite default_value/1 reporting nil for it" do
+      # Regression guard for the fix's own first cut, which derived nullability
+      # from `Ash.Query.Aggregate.default_value/1` alone and so typed every
+      # `exists` as `boolean | null`. That default is unreachable: an exists
+      # aggregate is a boolean predicate and the data layer yields `false` when
+      # nothing matches. Verified against a real load — a Todo with no comments
+      # comes back `has_comments: false`, not nil.
+      assert Ash.Query.Aggregate.default_value(:exists) == nil
+
+      refute Helpers.aggregate_allow_nil?(%Ash.Resource.Aggregate{kind: :exists})
     end
 
     test "an explicit default makes an otherwise-nullable aggregate non-nullable" do

--- a/test/ash_typescript/typescript_codegen_test.exs
+++ b/test/ash_typescript/typescript_codegen_test.exs
@@ -381,9 +381,67 @@ defmodule AshTypescript.CodegenTest do
   end
 
   describe "get_resource_field_spec/2 - aggregates" do
+    # An aggregate falls back to its kind's default when the relationship yields
+    # no rows, so nullability is exactly "is there a default to fall back to?".
+    # `count` and `list` have one; `avg`, `first`, `sum`, `min` and `max` do not.
+
     test "generates field spec for count aggregate" do
       result = Codegen.get_resource_field_spec(:comment_count, Todo)
       assert result == "  commentCount: number;"
+    end
+
+    test "list aggregate is not nullable - it defaults to an empty list" do
+      result = Codegen.get_resource_field_spec(:comment_authors, Todo)
+      assert result == "  commentAuthors: any[];"
+    end
+
+    test "avg aggregate is nullable - it is nil with no related rows" do
+      result = Codegen.get_resource_field_spec(:average_rating, Todo)
+      assert result == "  averageRating: number | null;"
+    end
+
+    test "first aggregate is nullable - it is nil with no related rows" do
+      result = Codegen.get_resource_field_spec(:latest_comment_content, Todo)
+      assert result == "  latestCommentContent: string | null;"
+    end
+  end
+
+  describe "Helpers.aggregate_allow_nil?/1" do
+    alias AshTypescript.Codegen.Helpers
+
+    test "is driven by the kind's default, not by include_nil?" do
+      # Regression guard. `include_nil?` controls whether nil values in the
+      # SOURCE rows take part in the computation; it says nothing about whether
+      # the aggregate itself can return nil. Because it defaults to false, using
+      # it here typed every aggregate as non-nullable.
+      for kind <- [:avg, :first, :sum, :min, :max] do
+        assert Helpers.aggregate_allow_nil?(%Ash.Resource.Aggregate{
+                 kind: kind,
+                 include_nil?: false
+               })
+
+        assert Helpers.aggregate_allow_nil?(%Ash.Resource.Aggregate{
+                 kind: kind,
+                 include_nil?: true
+               })
+      end
+
+      for kind <- [:count, :list] do
+        refute Helpers.aggregate_allow_nil?(%Ash.Resource.Aggregate{
+                 kind: kind,
+                 include_nil?: false
+               })
+
+        refute Helpers.aggregate_allow_nil?(%Ash.Resource.Aggregate{
+                 kind: kind,
+                 include_nil?: true
+               })
+      end
+    end
+
+    test "an explicit default makes an otherwise-nullable aggregate non-nullable" do
+      assert Helpers.aggregate_allow_nil?(%Ash.Resource.Aggregate{kind: :avg, default: nil})
+      refute Helpers.aggregate_allow_nil?(%Ash.Resource.Aggregate{kind: :avg, default: 0})
     end
   end
 


### PR DESCRIPTION
## The bug

Aggregate output nullability is read from `include_nil?`:

```elixir
# lib/ash_typescript/codegen/type_mapper.ex
if agg.include_nil? do
  "  #{formatted_field}: #{type} | null;"
```

`include_nil?` controls whether `nil` values in the **source** rows take part in the computation. It says nothing about whether the aggregate itself can return `nil`, and it defaults to `false` — so **every aggregate is currently typed as non-nullable.**

Attributes and calculations correctly use `allow_nil?` / `calc.allow_nil?`; only aggregates reach for the wrong flag. `Ash.Resource.Aggregate` has no `allow_nil?` key, which I think is how `include_nil?` got picked up as the nearest-looking option.

## The fix

An aggregate falls back to a default when the relationship yields no rows, so nullability is exactly *"is there a default to fall back to?"* — which Ash already answers via `Ash.Query.Aggregate.default_value/1`:

| kind | default | nullable |
|---|---|---|
| `count` | `0` | no |
| `list` | `[]` | no |
| `avg` / `first` / `sum` / `min` / `max` | `nil` | **yes** |

An explicit `default` on the aggregate overrides the kind's default and makes it non-nullable.

## Why it went unnoticed

The only aggregate covered by the suite was a `count` — the one kind `include_nil?: false` happens to type correctly. The full suite (2237 tests) passes unchanged with this fix; no test asserted the old behaviour.

This PR adds coverage for `avg`, `first` and `list` via the existing `Todo` test resource, plus unit tests pinning the rule and asserting `include_nil?` does **not** affect it. The four new tests fail on `main` and pass with the fix.

## Impact

Found while tracking down why a marketplace rating rendered as a crash rather than an empty state. An `avg` typed `number` instead of `number | null` lets this typecheck:

```ts
mode.avgRating.toFixed(1)   // runtime crash for any mode with no reviews
```

The worse case in our codebase was a `first` aggregate over a consent ledger, where `nil` is a meaningful third state ("never decided") that drives opposite defaults per purpose. Typing it `boolean` silently erased that state.

## Note for reviewers

This types `exists` as nullable, since `Ash.Query.Aggregate.default_value(:exists)` is `nil`. If `exists` is guaranteed `true`/`false` in practice, it deserves a `default_value` of `false` in Ash (or a special case here) — happy to adjust. Only `has_comments` in the test resource is affected, and no existing test asserts it.

I also noticed `get_resource_field_spec/2` raises `BadMapError` for a `sum` over a *calculation* field (`:total_weighted_score` in the test resource) on `main`, unrelated to this change — `lookup_aggregate_type/3` only looks up attributes. Left alone; happy to file separately.