### PR TITLE
docs: remove dead agent-plans/run-ts.md link from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,12 +320,6 @@ mix credo --strict                   # Linting
 | [testing-and-validation.md](agent-docs/testing-and-validation.md) | Test organization and validation procedures |
 | [architecture-decisions.md](agent-docs/architecture-decisions.md) | Architecture decisions and context |
 
-### Implementation Plans
-
-| File | Purpose |
-|------|----------|
-| [run-ts.md](agent-plans/run-ts.md) | Plan for TypeScript runtime validation - executing extracted TS calls via RPC |
-
 ### Implementation Documentation Guide
 
 **Consult these when modifying core systems:**


### PR DESCRIPTION
## Summary
- Remove the Implementation Plans table entry that linked to `agent-plans/run-ts.md`
- That path is not in the repository, so coding agents were being sent to a missing plan file

I noticed this while auditing AI coding-agent configuration with AgentDoctor.

## Test plan
- [x] Confirm `agent-plans/` is absent on current `main`
- [x] Confirm remaining markdown links in `AGENTS.md` resolve under `agent-docs/`