### PR TITLE
fix(codegen): propagate array min and max constraints

### DIFF
--- a/agent-docs/features/validation-schemas.md
+++ b/agent-docs/features/validation-schemas.md
@@ -18,7 +18,7 @@ AshTypescript generates runtime validation schemas alongside TypeScript types. T
 
 The schema generation uses a **formatter behaviour pattern** to avoid duplication:
 
-- **`SchemaFormatter`** (`codegen/schema_formatter.ex`) — Behaviour defining ~24 output-syntax callbacks (e.g. `wrap_optional`, `format_enum`, `format_string`, `library_prefix`)
+- **`SchemaFormatter`** (`codegen/schema_formatter.ex`) — Behaviour defining output-syntax callbacks (e.g. `wrap_optional`, `format_enum`, `format_string`, `format_array`, `library_prefix`)
 - **`SchemaCore`** (`codegen/schema_core.ex`) — All shared logic: topological sort, field/action introspection, type mapping dispatch, regex safety. Delegates output syntax to the formatter.
 - **`SharedSchemaGenerator`** (`codegen/shared_schema_generator.ex`) — Assembles the final schema file (imports, resource schemas, per-action schemas) for any formatter.
 
@@ -37,7 +37,7 @@ Each validation library is a thin adapter (~150 lines) implementing `SchemaForma
 | `:integer` | `z.number().int()` | `v.pipe(v.number(), v.integer())` |
 | `:boolean` | `z.boolean()` | `v.boolean()` |
 | `Ash.Type.UUID` | `z.uuid()` | `v.pipe(v.string(), v.uuid())` |
-| `{:array, inner}` | `z.array(inner)` | `v.array(inner)` |
+| `{:array, inner}` | `z.array(inner).min(...).max(...)` | `v.pipe(v.array(inner), v.minLength(...), v.maxLength(...))` |
 | Atom enum | `z.enum([...])` | `v.picklist([...])` |
 | Optional | `schema.optional()` | `v.optional(schema)` |
 
@@ -48,7 +48,9 @@ Constraints (min/max, string length, regex) are applied differently:
 - **Zod**: Method chaining — `z.string().min(1).max(100).regex(/pattern/)`
 - **Valibot**: Pipe composition — `v.pipe(v.string(), v.minLength(1), v.maxLength(100), v.regex(/pattern/))`
 
-The `format_string`, `format_integer`, and `format_float` callbacks handle these differences.
+The `format_string`, `format_integer`, `format_float`, and `format_array`
+callbacks handle these differences. Array `:items` constraints are applied recursively
+to the inner schema before outer `:min_length` and `:max_length` constraints.
 
 ## Configuration
 

--- a/lib/ash_typescript/codegen/schema_core.ex
+++ b/lib/ash_typescript/codegen/schema_core.ex
@@ -56,7 +56,8 @@ defmodule AshTypescript.Codegen.SchemaCore do
         {:array, inner_type} = type
         inner_constraints = Keyword.get(constraints, :items, [])
         inner_schema = map_type(formatter, inner_type, inner_constraints)
-        formatter.wrap_array(inner_schema)
+
+        formatter.format_array(inner_schema, constraints)
 
       Map.has_key?(simple_primitives, unwrapped_type) ->
         Map.get(simple_primitives, unwrapped_type)

--- a/lib/ash_typescript/codegen/schema_formatter.ex
+++ b/lib/ash_typescript/codegen/schema_formatter.ex
@@ -42,8 +42,8 @@ defmodule AshTypescript.Codegen.SchemaFormatter do
   @doc "Map of third-party Ash type modules (e.g. `AshMoney.Types.Money`) to schema strings."
   @callback third_party_types() :: %{module() => String.t()}
 
-  @doc "Wrap an inner schema string in an array type."
-  @callback wrap_array(inner :: String.t()) :: String.t()
+  @doc "Build an array schema, applying outer `:min_length` and `:max_length` constraints."
+  @callback format_array(inner :: String.t(), constraints :: keyword()) :: String.t()
 
   @doc """
   Wrap a schema string as omittable — i.e. the field may be absent from the

--- a/lib/ash_typescript/codegen/valibot_schema_generator.ex
+++ b/lib/ash_typescript/codegen/valibot_schema_generator.ex
@@ -86,7 +86,21 @@ defmodule AshTypescript.Codegen.ValibotSchemaGenerator do
   @impl true
   def third_party_types, do: @third_party_types
   @impl true
-  def wrap_array(inner), do: "v.array(#{inner})"
+  def format_array(inner, constraints) do
+    pipes =
+      []
+      |> add_pipe_if(
+        "v.minLength(#{Keyword.get(constraints, :min_length)})",
+        not is_nil(Keyword.get(constraints, :min_length))
+      )
+      |> add_pipe_if(
+        "v.maxLength(#{Keyword.get(constraints, :max_length)})",
+        not is_nil(Keyword.get(constraints, :max_length))
+      )
+
+    build_pipe("v.array(#{inner})", pipes)
+  end
+
   @impl true
   def wrap_optional(schema), do: "v.optional(#{schema})"
   @impl true

--- a/lib/ash_typescript/codegen/zod_schema_generator.ex
+++ b/lib/ash_typescript/codegen/zod_schema_generator.ex
@@ -86,7 +86,12 @@ defmodule AshTypescript.Codegen.ZodSchemaGenerator do
   @impl true
   def third_party_types, do: @third_party_types
   @impl true
-  def wrap_array(inner), do: "z.array(#{inner})"
+  def format_array(inner, constraints) do
+    "z.array(#{inner})"
+    |> add_min(Keyword.get(constraints, :min_length))
+    |> add_max(Keyword.get(constraints, :max_length))
+  end
+
   @impl true
   def wrap_optional(schema), do: "#{schema}.optional()"
   @impl true

--- a/test/ash_typescript/rpc/valibot_constraints_test.exs
+++ b/test/ash_typescript/rpc/valibot_constraints_test.exs
@@ -17,6 +17,7 @@ defmodule AshTypescript.Rpc.ValibotConstraintsTest do
   use ExUnit.Case, async: true
 
   alias AshTypescript.Codegen.ValibotSchemaGenerator
+  alias AshTypescript.Test.NestedArrayConstraints
   alias AshTypescript.Test.OrgTodo
 
   describe "Integer constraints in Valibot schemas" do
@@ -69,6 +70,75 @@ defmodule AshTypescript.Rpc.ValibotConstraintsTest do
 
       # Regression: the old buggy output was v.string().min(1) — must never appear
       refute schema =~ "v.string().min("
+    end
+  end
+
+  describe "Array constraints in Valibot schemas" do
+    test "generates min_length constraint for array arguments" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+
+      schema =
+        ValibotSchemaGenerator.generate_valibot_schema(OrgTodo, action, "array_constraints")
+
+      assert schema =~
+               "minimumReferenceIds: v.pipe(v.array(v.pipe(v.string(), v.uuid())), v.minLength(1))"
+    end
+
+    test "generates max_length constraint for array arguments" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+
+      schema =
+        ValibotSchemaGenerator.generate_valibot_schema(OrgTodo, action, "array_constraints")
+
+      assert schema =~
+               "maximumReferenceIds: v.pipe(v.array(v.pipe(v.string(), v.uuid())), v.maxLength(16))"
+    end
+
+    test "generates both array cardinality constraints" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+
+      schema =
+        ValibotSchemaGenerator.generate_valibot_schema(OrgTodo, action, "array_constraints")
+
+      assert schema =~
+               "boundedReferenceIds: v.pipe(v.array(v.pipe(v.string(), v.uuid())), v.minLength(1), v.maxLength(16))"
+    end
+
+    test "preserves item constraints alongside array cardinality constraints" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+
+      schema =
+        ValibotSchemaGenerator.generate_valibot_schema(OrgTodo, action, "array_constraints")
+
+      assert schema =~
+               "boundedCodes: v.pipe(v.array(v.pipe(v.string(), v.minLength(2), v.maxLength(8))), v.minLength(1), v.maxLength(4))"
+    end
+
+    test "applies nested array cardinality constraints at the correct level" do
+      action = Ash.Resource.Info.action(NestedArrayConstraints, :validate)
+
+      schema =
+        ValibotSchemaGenerator.generate_valibot_schema(
+          NestedArrayConstraints,
+          action,
+          "array_constraints"
+        )
+
+      assert schema =~
+               "boundedMatrix: v.pipe(v.array(v.pipe(v.array(v.pipe(v.number(), v.integer())), v.minLength(2), v.maxLength(3))), v.minLength(1), v.maxLength(2))"
+    end
+
+    test "applies array constraints before optional and nullable wrappers" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+
+      schema =
+        ValibotSchemaGenerator.generate_valibot_schema(OrgTodo, action, "array_constraints")
+
+      assert schema =~
+               "optionalReferenceIds: v.optional(v.pipe(v.array(v.pipe(v.string(), v.uuid())), v.maxLength(16)))"
+
+      assert schema =~
+               "nullableReferenceIds: v.optional(v.nullable(v.pipe(v.array(v.pipe(v.string(), v.uuid())), v.minLength(1))))"
     end
   end
 

--- a/test/ash_typescript/rpc/zod_constraints_test.exs
+++ b/test/ash_typescript/rpc/zod_constraints_test.exs
@@ -16,6 +16,7 @@ defmodule AshTypescript.Rpc.ZodConstraintsTest do
   use ExUnit.Case, async: true
 
   alias AshTypescript.Codegen.ZodSchemaGenerator
+  alias AshTypescript.Test.NestedArrayConstraints
   alias AshTypescript.Test.OrgTodo
 
   describe "Integer constraints in Zod schemas" do
@@ -74,6 +75,68 @@ defmodule AshTypescript.Rpc.ZodConstraintsTest do
       assert zod_schema =~ "description: z.string().nullable().optional()"
       refute zod_schema =~ ~r/description.*\.min\(/
       refute zod_schema =~ ~r/description.*\.max\(/
+    end
+  end
+
+  describe "Array constraints in Zod schemas" do
+    test "generates min_length constraint for array arguments" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+
+      zod_schema =
+        ZodSchemaGenerator.generate_zod_schema(
+          OrgTodo,
+          action,
+          "array_constraints"
+        )
+
+      assert zod_schema =~ "minimumReferenceIds: z.array(z.uuid()).min(1)"
+    end
+
+    test "generates max_length constraint for array arguments" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+      zod_schema = ZodSchemaGenerator.generate_zod_schema(OrgTodo, action, "array_constraints")
+
+      assert zod_schema =~ "maximumReferenceIds: z.array(z.uuid()).max(16)"
+    end
+
+    test "generates both array cardinality constraints" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+      zod_schema = ZodSchemaGenerator.generate_zod_schema(OrgTodo, action, "array_constraints")
+
+      assert zod_schema =~ "boundedReferenceIds: z.array(z.uuid()).min(1).max(16)"
+    end
+
+    test "preserves item constraints alongside array cardinality constraints" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+      zod_schema = ZodSchemaGenerator.generate_zod_schema(OrgTodo, action, "array_constraints")
+
+      assert zod_schema =~
+               "boundedCodes: z.array(z.string().min(2).max(8)).min(1).max(4)"
+    end
+
+    test "applies nested array cardinality constraints at the correct level" do
+      action = Ash.Resource.Info.action(NestedArrayConstraints, :validate)
+
+      zod_schema =
+        ZodSchemaGenerator.generate_zod_schema(
+          NestedArrayConstraints,
+          action,
+          "array_constraints"
+        )
+
+      assert zod_schema =~
+               "boundedMatrix: z.array(z.array(z.number().int()).min(2).max(3)).min(1).max(2)"
+    end
+
+    test "applies array constraints before optional and nullable wrappers" do
+      action = Ash.Resource.Info.action(OrgTodo, :validate_array_constraints)
+      zod_schema = ZodSchemaGenerator.generate_zod_schema(OrgTodo, action, "array_constraints")
+
+      assert zod_schema =~
+               "optionalReferenceIds: z.array(z.uuid()).max(16).optional()"
+
+      assert zod_schema =~
+               "nullableReferenceIds: z.array(z.uuid()).min(1).nullable().optional()"
     end
   end
 

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -166,6 +166,7 @@ defmodule AshTypescript.Test.Domain do
       rpc_action :complete_org_todo, :complete
       rpc_action :set_priority_org_todo, :set_priority
       rpc_action :bulk_complete_org_todo, :bulk_complete
+      rpc_action :validate_array_constraints_org_todo, :validate_array_constraints
       rpc_action :get_statistics_org_todo, :get_statistics
       rpc_action :search_org_todos, :search
       rpc_action :destroy_org_todo, :destroy

--- a/test/support/resources/nested_array_constraints.ex
+++ b/test/support/resources/nested_array_constraints.ex
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 ash_typescript contributors <https://github.com/ash-project/ash_typescript/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshTypescript.Test.NestedArrayConstraints do
+  @moduledoc false
+
+  use Ash.Resource, domain: nil
+
+  actions do
+    action :validate, :boolean do
+      argument :bounded_matrix, {:array, {:array, :integer}} do
+        allow_nil? false
+        constraints min_length: 1, max_length: 2, items: [min_length: 2, max_length: 3]
+      end
+
+      run fn _input, _context -> {:ok, true} end
+    end
+  end
+end

--- a/test/support/resources/org_todo.ex
+++ b/test/support/resources/org_todo.ex
@@ -303,6 +303,41 @@ defmodule AshTypescript.Test.OrgTodo do
       end
     end
 
+    action :validate_array_constraints, :boolean do
+      argument :minimum_reference_ids, {:array, :uuid} do
+        allow_nil? false
+        constraints min_length: 1
+      end
+
+      argument :maximum_reference_ids, {:array, :uuid} do
+        allow_nil? false
+        constraints max_length: 16
+      end
+
+      argument :bounded_reference_ids, {:array, :uuid} do
+        allow_nil? false
+        constraints min_length: 1, max_length: 16
+      end
+
+      argument :bounded_codes, {:array, :string} do
+        allow_nil? false
+        constraints min_length: 1, max_length: 4, items: [min_length: 2, max_length: 8]
+      end
+
+      argument :optional_reference_ids, {:array, :uuid} do
+        allow_nil? false
+        default []
+        constraints max_length: 16
+      end
+
+      argument :nullable_reference_ids, {:array, :uuid} do
+        allow_nil? true
+        constraints min_length: 1
+      end
+
+      run fn _input, _context -> {:ok, true} end
+    end
+
     action :get_statistics, :map do
       constraints fields: [
                     total: [type: :integer, allow_nil?: false],

--- a/test/ts/runValibotTests.ts
+++ b/test/ts/runValibotTests.ts
@@ -79,6 +79,9 @@ runTest("testNullableTypedStructAcceptsNull", () => shouldPass.testNullableTyped
 runTest("testUpdateTaskAllOmittable", () => shouldPass.testUpdateTaskAllOmittable());
 runTest("testUpdateTaskOmittableTitleAcceptsValue", () => shouldPass.testUpdateTaskOmittableTitleAcceptsValue());
 runTest("testUpdateTaskOmittableArchivedAcceptsValue", () => shouldPass.testUpdateTaskOmittableArchivedAcceptsValue());
+runTest("testArrayCardinalityBoundaries", () => shouldPass.testArrayCardinalityBoundaries());
+runTest("testOptionalArrayOmitted", () => shouldPass.testOptionalArrayOmitted());
+runTest("testNullableArrayAcceptsNull", () => shouldPass.testNullableArrayAcceptsNull());
 
 console.log("\n--- Tests that SHOULD FAIL (invalid constraints) ---\n");
 
@@ -128,6 +131,10 @@ runTest("testMoneyWrongFieldTypes", () => shouldFail.testMoneyWrongFieldTypes())
 runTest("testOmittableOnlyTitleRejectsNull", () => shouldFail.testOmittableOnlyTitleRejectsNull());
 runTest("testOmittableOnlyArchivedRejectsNull", () => shouldFail.testOmittableOnlyArchivedRejectsNull());
 runTest("testRequiredTitleRejectsNullOnCreate", () => shouldFail.testRequiredTitleRejectsNullOnCreate());
+runTest("testArrayBelowMinimum", () => shouldFail.testArrayBelowMinimum());
+runTest("testArrayAboveMaximum", () => shouldFail.testArrayAboveMaximum());
+runTest("testArrayItemConstraintViolation", () => shouldFail.testArrayItemConstraintViolation());
+runTest("testOptionalArrayRejectsNull", () => shouldFail.testOptionalArrayRejectsNull());
 
 console.log("\n========================================");
 console.log("Test Results Summary");

--- a/test/ts/runZodTests.ts
+++ b/test/ts/runZodTests.ts
@@ -79,6 +79,9 @@ runTest("testNullableTypedStructAcceptsNull", () => shouldPass.testNullableTyped
 runTest("testUpdateTaskAllOmittable", () => shouldPass.testUpdateTaskAllOmittable());
 runTest("testUpdateTaskOmittableTitleAcceptsValue", () => shouldPass.testUpdateTaskOmittableTitleAcceptsValue());
 runTest("testUpdateTaskOmittableArchivedAcceptsValue", () => shouldPass.testUpdateTaskOmittableArchivedAcceptsValue());
+runTest("testArrayCardinalityBoundaries", () => shouldPass.testArrayCardinalityBoundaries());
+runTest("testOptionalArrayOmitted", () => shouldPass.testOptionalArrayOmitted());
+runTest("testNullableArrayAcceptsNull", () => shouldPass.testNullableArrayAcceptsNull());
 
 console.log("\n--- Tests that SHOULD FAIL (invalid constraints) ---\n");
 
@@ -128,6 +131,10 @@ runTest("testMoneyWrongFieldTypes", () => shouldFail.testMoneyWrongFieldTypes())
 runTest("testOmittableOnlyTitleRejectsNull", () => shouldFail.testOmittableOnlyTitleRejectsNull());
 runTest("testOmittableOnlyArchivedRejectsNull", () => shouldFail.testOmittableOnlyArchivedRejectsNull());
 runTest("testRequiredTitleRejectsNullOnCreate", () => shouldFail.testRequiredTitleRejectsNullOnCreate());
+runTest("testArrayBelowMinimum", () => shouldFail.testArrayBelowMinimum());
+runTest("testArrayAboveMaximum", () => shouldFail.testArrayAboveMaximum());
+runTest("testArrayItemConstraintViolation", () => shouldFail.testArrayItemConstraintViolation());
+runTest("testOptionalArrayRejectsNull", () => shouldFail.testOptionalArrayRejectsNull());
 
 console.log("\n========================================");
 console.log("Test Results Summary");

--- a/test/ts/valibot/shouldFail/constraintValidation.ts
+++ b/test/ts/valibot/shouldFail/constraintValidation.ts
@@ -7,6 +7,7 @@ import {
   createOrgTodoValibotSchema,
   createTaskValibotSchema,
   updateTaskValibotSchema,
+  validateArrayConstraintsOrgTodoValibotSchema,
   AshTypescriptTestTodoContentLinkContentValibotSchema,
 } from "../../ash_valibot";
 
@@ -1043,6 +1044,57 @@ export function testRequiredTitleRejectsNullOnCreate() {
     }
     throw error;
   }
+}
+
+function createValidArrayConstraintData() {
+  const uuid = "123e4567-e89b-12d3-a456-426614174000";
+
+  return {
+    minimumReferenceIds: [uuid],
+    maximumReferenceIds: [uuid],
+    boundedReferenceIds: [uuid],
+    boundedCodes: ["valid"],
+  };
+}
+
+function expectArrayConstraintFailure(input: unknown) {
+  const result = v.safeParse(validateArrayConstraintsOrgTodoValibotSchema, input);
+
+  if (result.success) {
+    throw new Error("Should have failed array constraint validation");
+  }
+
+  return result.issues;
+}
+
+export function testArrayBelowMinimum() {
+  return expectArrayConstraintFailure({
+    ...createValidArrayConstraintData(),
+    minimumReferenceIds: [],
+  });
+}
+
+export function testArrayAboveMaximum() {
+  const uuid = "123e4567-e89b-12d3-a456-426614174000";
+
+  return expectArrayConstraintFailure({
+    ...createValidArrayConstraintData(),
+    maximumReferenceIds: Array(17).fill(uuid),
+  });
+}
+
+export function testArrayItemConstraintViolation() {
+  return expectArrayConstraintFailure({
+    ...createValidArrayConstraintData(),
+    boundedCodes: ["x"],
+  });
+}
+
+export function testOptionalArrayRejectsNull() {
+  return expectArrayConstraintFailure({
+    ...createValidArrayConstraintData(),
+    optionalReferenceIds: null,
+  });
 }
 
 console.log("Constraint validation failure tests should compile successfully!");

--- a/test/ts/valibot/shouldPass/constraintValidation.ts
+++ b/test/ts/valibot/shouldPass/constraintValidation.ts
@@ -7,6 +7,7 @@ import {
   createOrgTodoValibotSchema,
   createTaskValibotSchema,
   updateTaskValibotSchema,
+  validateArrayConstraintsOrgTodoValibotSchema,
   AshTypescriptTestTodoContentLinkContentValibotSchema,
 } from "../../ash_valibot";
 
@@ -591,6 +592,44 @@ export function testUpdateTaskOmittableArchivedAcceptsValue() {
   }
   console.log("Omittable-only isArchived accepts a value");
   return validated;
+}
+
+function createValidArrayConstraintData() {
+  const uuid = "123e4567-e89b-12d3-a456-426614174000";
+
+  return {
+    minimumReferenceIds: [uuid],
+    maximumReferenceIds: Array(16).fill(uuid),
+    boundedReferenceIds: Array(16).fill(uuid),
+    boundedCodes: ["ab", "12345678", "valid", "code"],
+  };
+}
+
+export function testArrayCardinalityBoundaries() {
+  return v.parse(
+    validateArrayConstraintsOrgTodoValibotSchema,
+    createValidArrayConstraintData(),
+  );
+}
+
+export function testOptionalArrayOmitted() {
+  const validated = v.parse(
+    validateArrayConstraintsOrgTodoValibotSchema,
+    createValidArrayConstraintData(),
+  );
+
+  if (validated.optionalReferenceIds !== undefined) {
+    throw new Error("Expected optionalReferenceIds to be omitted");
+  }
+
+  return validated;
+}
+
+export function testNullableArrayAcceptsNull() {
+  return v.parse(validateArrayConstraintsOrgTodoValibotSchema, {
+    ...createValidArrayConstraintData(),
+    nullableReferenceIds: null,
+  });
 }
 
 console.log("Valibot Constraint validation tests should compile and pass successfully!");

--- a/test/ts/zod/shouldFail/constraintValidation.ts
+++ b/test/ts/zod/shouldFail/constraintValidation.ts
@@ -7,6 +7,7 @@ import {
   createOrgTodoZodSchema,
   createTaskZodSchema,
   updateTaskZodSchema,
+  validateArrayConstraintsOrgTodoZodSchema,
   AshTypescriptTestTodoContentLinkContentZodSchema,
 } from "../../ash_zod";
 
@@ -1030,6 +1031,57 @@ export function testRequiredTitleRejectsNullOnCreate() {
     }
     throw error;
   }
+}
+
+function createValidArrayConstraintData() {
+  const uuid = "123e4567-e89b-12d3-a456-426614174000";
+
+  return {
+    minimumReferenceIds: [uuid],
+    maximumReferenceIds: [uuid],
+    boundedReferenceIds: [uuid],
+    boundedCodes: ["valid"],
+  };
+}
+
+function expectArrayConstraintFailure(input: unknown) {
+  const result = validateArrayConstraintsOrgTodoZodSchema.safeParse(input);
+
+  if (result.success) {
+    throw new Error("Should have failed array constraint validation");
+  }
+
+  return result.error.issues;
+}
+
+export function testArrayBelowMinimum() {
+  return expectArrayConstraintFailure({
+    ...createValidArrayConstraintData(),
+    minimumReferenceIds: [],
+  });
+}
+
+export function testArrayAboveMaximum() {
+  const uuid = "123e4567-e89b-12d3-a456-426614174000";
+
+  return expectArrayConstraintFailure({
+    ...createValidArrayConstraintData(),
+    maximumReferenceIds: Array(17).fill(uuid),
+  });
+}
+
+export function testArrayItemConstraintViolation() {
+  return expectArrayConstraintFailure({
+    ...createValidArrayConstraintData(),
+    boundedCodes: ["x"],
+  });
+}
+
+export function testOptionalArrayRejectsNull() {
+  return expectArrayConstraintFailure({
+    ...createValidArrayConstraintData(),
+    optionalReferenceIds: null,
+  });
 }
 
 console.log("Constraint validation failure tests should compile successfully!");

--- a/test/ts/zod/shouldPass/constraintValidation.ts
+++ b/test/ts/zod/shouldPass/constraintValidation.ts
@@ -8,6 +8,7 @@ import {
   createOrgTodoZodSchema,
   createTaskZodSchema,
   updateTaskZodSchema,
+  validateArrayConstraintsOrgTodoZodSchema,
   AshTypescriptTestTodoContentLinkContentZodSchema,
 } from "../../ash_zod";
 
@@ -605,6 +606,40 @@ export function testUpdateTaskOmittableArchivedAcceptsValue() {
   }
   console.log("Omittable-only isArchived accepts a value");
   return validated;
+}
+
+function createValidArrayConstraintData() {
+  const uuid = "123e4567-e89b-12d3-a456-426614174000";
+
+  return {
+    minimumReferenceIds: [uuid],
+    maximumReferenceIds: Array(16).fill(uuid),
+    boundedReferenceIds: Array(16).fill(uuid),
+    boundedCodes: ["ab", "12345678", "valid", "code"],
+  };
+}
+
+export function testArrayCardinalityBoundaries() {
+  return validateArrayConstraintsOrgTodoZodSchema.parse(createValidArrayConstraintData());
+}
+
+export function testOptionalArrayOmitted() {
+  const validated = validateArrayConstraintsOrgTodoZodSchema.parse(
+    createValidArrayConstraintData(),
+  );
+
+  if (validated.optionalReferenceIds !== undefined) {
+    throw new Error("Expected optionalReferenceIds to be omitted");
+  }
+
+  return validated;
+}
+
+export function testNullableArrayAcceptsNull() {
+  return validateArrayConstraintsOrgTodoZodSchema.parse({
+    ...createValidArrayConstraintData(),
+    nullableReferenceIds: null,
+  });
 }
 
 console.log("Constraint validation tests should compile and pass successfully!");


### PR DESCRIPTION
> This description was drafted with AI assistance and reviewed by the submitter.

Propagates Ash array `min_length` and `max_length` constraints into generated Zod and Valibot schemas.

This replaces `wrap_array/1` with the required `format_array/2` formatter callback. Making it required is intentional: every formatter must explicitly render array constraints instead of silently generating weaker validation.

Includes coverage for item constraints, nested cardinality, nullable/optional arrays, and runtime boundary validation.

# Contributor checklist
Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies